### PR TITLE
Activate EvapTrans without CLM compilation

### DIFF
--- a/pfsimulator/amps/oas3/oas_pfl_define.F90
+++ b/pfsimulator/amps/oas3/oas_pfl_define.F90
@@ -92,7 +92,7 @@ INTEGER                                    ::  status, pflncid,  &!
 !------------------------------------------------------------------------------
 !- Begin Subroutine oas_pfl_define 
 !------------------------------------------------------------------------------
-!
+#ifdef READCLM
 ! Read in land mask for each sub-domain to mask recv values from CLM
 ALLOCATE( mask_land_sub(nx,ny), stat = ierror )
 IF (ierror >0) CALL prism_abort_proto(comp_id, 'oas_pfl_define', 'Failure in allocating mask_land_sub')
@@ -108,6 +108,7 @@ DO ib = 0,npes-1
    mask_land_sub = mask_land_sub
   ENDIF
 ENDDO
+#endif
 
 
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/pfsimulator/amps/oas3/oas_pfl_vardef.F90
+++ b/pfsimulator/amps/oas3/oas_pfl_vardef.F90
@@ -49,6 +49,8 @@ INTEGER                                   :: info
 INTEGER, PUBLIC                           :: OASIS_Rcv  = 1        ! return code if received field
 INTEGER, PUBLIC                           :: OASIS_idle = 0        ! return code if nothing done by oasis
 
+INTEGER, DIMENSION(:,:), ALLOCATABLE      :: mask_land             ! Mask land
+INTEGER, DIMENSION(:,:), ALLOCATABLE      :: mask_land_sub         ! Mask land
 !
 REAL(KIND=8), DIMENSION(:,:), ALLOCATABLE :: bufz                  ! Temp buffer for field transfer
 REAL(KIND=8)                              :: pfl_timestep,        &! parflow time step in hrs

--- a/pfsimulator/amps/oas3/receive_fld2_clm.F90
+++ b/pfsimulator/amps/oas3/receive_fld2_clm.F90
@@ -49,7 +49,6 @@ REAL(KIND=8), INTENT(INOUT)        :: evap_trans((nx+2)*(ny+2)*(nz+2))   ! sourc
 
                                                                          ! All vecotrs from parflow on grid w/ ghost nodes for current proc
 !Local Variables 
-
 INTEGER                            :: i, j, k, l
 INTEGER                            :: isecs                              ! Parflow model time in seconds
 INTEGER                            :: j_incr, k_incr                     ! convert 1D vector to 3D i,j,k array
@@ -96,7 +95,6 @@ CHARACTER(len=19)                  :: foupname
     ENDDO
  ENDDO
 
-!
  DO k = 1, nlevsoil
    IF( trcv(k)%laction )  CALL oas_pfl_rcv( k, isecs, frcv(:,:,k),nx, ny, info )
  ENDDO
@@ -105,7 +103,7 @@ CHARACTER(len=19)                  :: foupname
  DO i = 1, nx
    DO j = 1, ny
      DO k = 1, nlevsoil 
-       IF (topo_mask(i,j) .gt. 0) THEN                    !CPS mask bug fix
+       IF ((topo_mask(i,j) .gt. 0) .and. (mask_land_sub(i,j) .gt. 0)) THEN                    !CPS mask bug fix
          l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
          evap_trans(l) = frcv(i,j,k)
        END IF

--- a/pfsimulator/amps/oas3/receive_fld2_clm.F90
+++ b/pfsimulator/amps/oas3/receive_fld2_clm.F90
@@ -99,6 +99,7 @@ CHARACTER(len=19)                  :: foupname
    IF( trcv(k)%laction )  CALL oas_pfl_rcv( k, isecs, frcv(:,:,k),nx, ny, info )
  ENDDO
 !
+#ifdef READCLM
  evap_trans = 0.   !CPS initialize for masking
  DO i = 1, nx
    DO j = 1, ny
@@ -110,6 +111,19 @@ CHARACTER(len=19)                  :: foupname
      ENDDO
    ENDDO
  ENDDO
+#else
+ evap_trans = 0.   !CPS initialize for masking
+ DO i = 1, nx
+   DO j = 1, ny
+     DO k = 1, nlevsoil 
+       IF (topo_mask(i,j) .gt. 0) THEN                    !CPS mask bug fix
+         l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
+         evap_trans(l) = frcv(i,j,k)
+       END IF
+     ENDDO
+   ENDDO
+ ENDDO
+#endif
 
 ! Debug ouput file
  IF ( IOASISDEBUGLVL == 1 ) THEN

--- a/pfsimulator/amps/oas3/receive_fld2_clm.F90
+++ b/pfsimulator/amps/oas3/receive_fld2_clm.F90
@@ -100,25 +100,23 @@ CHARACTER(len=19)                  :: foupname
  ENDDO
 !
 #ifdef READCLM
- evap_trans = 0.   !CPS initialize for masking
  DO i = 1, nx
    DO j = 1, ny
      DO k = 1, nlevsoil 
        IF ((topo_mask(i,j) .gt. 0) .and. (mask_land_sub(i,j) .gt. 0)) THEN                    !CPS mask bug fix
          l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
-         evap_trans(l) = frcv(i,j,k)
+         evap_trans(l) = evap_trans(l) + frcv(i,j,k)
        END IF
      ENDDO
    ENDDO
  ENDDO
 #else
- evap_trans = 0.   !CPS initialize for masking
  DO i = 1, nx
    DO j = 1, ny
      DO k = 1, nlevsoil 
        IF (topo_mask(i,j) .gt. 0) THEN                    !CPS mask bug fix
          l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
-         evap_trans(l) = frcv(i,j,k)
+         evap_trans(l) = evap_trans(l) + frcv(i,j,k)
        END IF
      ENDDO
    ENDDO


### PR DESCRIPTION
    - In TSMP we cannot use EvapTrans as ParFlow must be compiled with
      CLM to use this option. However, we need this in TSMP to simulate
      e.g. human water consumption. As EvapTrans works fine even without
      CLM compiled, we can simply move the routine that reads in the
      EvapTrans forcing file outside the `ifdef HAVE_CLM` option.
      To ensure no interference if CLM is compiled, all relevant changes
      are placed in `ifndef HAVE_CLM' compiler flags to be used only if
      CLM is not compiled.
    - Change coupling behaviour to not replace `evap_trans` in ParFlow
      with OASIS (=), but to add the fields sent by CLM (+=). This way
      EvapTrans and CLM coupling can be used together and the forcing
      is summed up for ParFlow.
    - It is ensured that the above changes do not introduce additional
      mandatory forcing files as `evap_trans` is initialized to 0 and
      reset at the beginning of each time loop.