### PR TITLE
UPDATE oas3 interface to use clmgrid.nc for masking recv fields

### DIFF
--- a/pfsimulator/amps/oas3/oas_pfl_vardef.F90
+++ b/pfsimulator/amps/oas3/oas_pfl_vardef.F90
@@ -49,6 +49,8 @@ INTEGER                                   :: info
 INTEGER, PUBLIC                           :: OASIS_Rcv  = 1        ! return code if received field
 INTEGER, PUBLIC                           :: OASIS_idle = 0        ! return code if nothing done by oasis
 
+INTEGER, DIMENSION(:,:), ALLOCATABLE      :: mask_land             ! Mask land
+INTEGER, DIMENSION(:,:), ALLOCATABLE      :: mask_land_sub         ! Mask land
 !
 REAL(KIND=8), DIMENSION(:,:), ALLOCATABLE :: bufz                  ! Temp buffer for field transfer
 REAL(KIND=8)                              :: pfl_timestep,        &! parflow time step in hrs

--- a/pfsimulator/amps/oas3/receive_fld2_clm.F90
+++ b/pfsimulator/amps/oas3/receive_fld2_clm.F90
@@ -49,7 +49,6 @@ REAL(KIND=8), INTENT(INOUT)        :: evap_trans((nx+2)*(ny+2)*(nz+2))   ! sourc
 
                                                                          ! All vecotrs from parflow on grid w/ ghost nodes for current proc
 !Local Variables 
-
 INTEGER                            :: i, j, k, l
 INTEGER                            :: isecs                              ! Parflow model time in seconds
 INTEGER                            :: j_incr, k_incr                     ! convert 1D vector to 3D i,j,k array
@@ -96,7 +95,6 @@ CHARACTER(len=19)                  :: foupname
     ENDDO
  ENDDO
 
-!
  DO k = 1, nlevsoil
    IF( trcv(k)%laction )  CALL oas_pfl_rcv( k, isecs, frcv(:,:,k),nx, ny, info )
  ENDDO
@@ -105,7 +103,7 @@ CHARACTER(len=19)                  :: foupname
  DO i = 1, nx
    DO j = 1, ny
      DO k = 1, nlevsoil 
-       IF (topo_mask(i,j) .gt. 0) THEN                    !CPS mask bug fix
+       IF ((topo_mask(i,j) .gt. 0) .and. (mask_land_sub(i,j) .gt. 0)) THEN                    !CPS mask bug fix
          l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
          evap_trans(l) = frcv(i,j,k)
        END IF


### PR DESCRIPTION
- The currently implemented oas3 interface used by TSMP only masks rcv fields from CLM35 by inactive or active parflow cells. This only works if ParFlow and CLM share the same land-water mask (active and inactive cells). To work around this, it is now implemented that ParFlow additionally masks rcv fields using the mask that is shipped with clmgrid.nc to ensure that all inactive pixels from CLM are also masked out in ParFlow.

c/o @niklaswr 