### PR TITLE
Activate EvapTrans without CLM compilation

### DIFF
--- a/pfsimulator/amps/oas3/receive_fld2_clm.F90
+++ b/pfsimulator/amps/oas3/receive_fld2_clm.F90
@@ -99,17 +99,16 @@ CHARACTER(len=19)                  :: foupname
    IF( trcv(k)%laction )  CALL oas_pfl_rcv( k, isecs, frcv(:,:,k),nx, ny, info )
  ENDDO
 !
- evap_trans = 0.   !CPS initialize for masking
- DO i = 1, nx
-   DO j = 1, ny
-     DO k = 1, nlevsoil 
-       IF ((topo_mask(i,j) .gt. 0) .and. (mask_land_sub(i,j) .gt. 0)) THEN                    !CPS mask bug fix
-         l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
-         evap_trans(l) = frcv(i,j,k)
-       END IF
-     ENDDO
-   ENDDO
- ENDDO
+DO i = 1, nx
+  DO j = 1, ny
+    DO k = 1, nlevsoil 
+      IF ((topo_mask(i,j) .gt. 0) .and. (mask_land_sub(i,j) .gt. 0)) THEN                    !CPS mask bug fix
+        l = 1+i + j_incr*(j) + k_incr*(topo_mask(i,j)-(k-1))  !
+        evap_trans(l) = evap_trans(l) + frcv(i,j,k)
+      END IF
+    ENDDO
+  ENDDO
+ENDDO
 
 ! Debug ouput file
  IF ( IOASISDEBUGLVL == 1 ) THEN


### PR DESCRIPTION
- In TSMP we cannot use EvapTrans as ParFlow must be compiled with CLM to use this option. However, we need this in TSMP to simulate e.g. human water consumption. As EvapTrans works fine even without CLM compiled, we can simply move the routine that reads in the EvapTrans forcing file outside the `ifdef HAVE_CLM` option. To ensure no interference if CLM is compiled, all relevant changes are placed in `ifndef HAVE_CLM' compiler flags to be used only if CLM is not compiled.
- Change coupling behaviour to not replace `evap_trans` in ParFlow with OASIS (=), but to add the fields sent by CLM (+=). This way EvapTrans and CLM coupling can be used together and the forcing is summed up for ParFlow.
- It is ensured that the above changes do not introduce additional mandatory forcing files as `evap_trans` is initialised to 0 and reset at the beginning of each time loop.

Co-authored-by: @niklaswr