### PR TITLE
FindOASIS.cmake: Add NetCDF_Fortran_INCLUDES

### DIFF
--- a/cmake/modules/FindOASIS.cmake
+++ b/cmake/modules/FindOASIS.cmake
@@ -22,5 +22,6 @@ if(OASIS_FOUND AND NOT TARGET OASIS3MCT::OASIS3MCT)
   target_link_libraries(OASIS3MCT::OASIS3MCT INTERFACE ${OASIS_Fortran_LIBRARY} ${MCT_Fortran_LIBRARY} ${MPEU_Fortran_LIBRARY} ${SCRIP_Fortran_LIBRARY})
   target_link_libraries(OASIS3MCT::OASIS3MCT INTERFACE OpenMP::OpenMP_Fortran)
   target_link_libraries(OASIS3MCT::OASIS3MCT INTERFACE ${NETCDF_Fortran_LIBRARY})
+  target_include_directories(OASIS3MCT::OASIS3MCT INTERFACE ${NETCDF_Fortran_INCLUDES})
 endif()
 


### PR DESCRIPTION
related to HPSCTerrSys/TSMP2#123

fixing module error in CLM3.5-ParFlow-PDAF compilation on Stages/2026

```
TSMP2/models/parflow_pdaf/pfsimulator/amps/oas3/oas_pfl_define.F90:38:5:

   38 | USE netcdf
      |     1
Fatal Error: Cannot open module file ‘netcdf.mod’ for reading at (1): No such file or directory
compilation terminated.
```