### PR TITLE
wrf_parflow: declare Solver_module as extern

### DIFF
--- a/pfsimulator/parflow_lib/wrf_parflow.c
+++ b/pfsimulator/parflow_lib/wrf_parflow.c
@@ -36,7 +36,8 @@
 
 #include <string.h>
 
-amps_ThreadLocalDcl(PFModule *, Solver_module);
+extern PFModule *Solver_module;  /* defined in solver.c */
+/* amps_ThreadLocalDcl(PFModule *, Solver_module); */
 amps_ThreadLocalDcl(PFModule *, solver);
 amps_ThreadLocalDcl(Vector   *, evap_trans);
 


### PR DESCRIPTION
related to HPSCTerrSys/TSMP2#123

Fixing error `multiple definition of Solver_module` during linking step of CLM3.5-ParFlow-PDAF

```
/p/software/default/stages/2026/software/binutils/2.44-GCCcore-14.3.0/bin/ld: TSMP2/bin/JUWELS_ParFlow-CLM3.5-PDAF/lib/libpfsimulator.a(wrf_parflow.c.o):(.bss+0x10): multiple definition of `Solver_module'; TSMP2/bin/JUWELS_ParFlow-CLM3.5-PDAF/lib/libpfsimulator.a(solver.c.o):(.bss+0x0): first defined here
```